### PR TITLE
Fix typo in zulu-jdk17 cask name.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -59,7 +59,7 @@ Using Homebrew to setup your machine, you can run the following commands to get 
 
 ```console
 brew tap mdogan/zulu
-brew install --cask zulu-jdk8 zulu-jdk11 zulu-jdk-17
+brew install --cask zulu-jdk8 zulu-jdk11 zulu-jdk17
 ```
 
 To install without Homebrew you can follow these instructions: [https://docs.azul.com/core/zulu-openjdk/install/macos](https://docs.azul.com/core/zulu-openjdk/install/macos)


### PR DESCRIPTION
Reference: https://github.com/mdogan/homebrew-zulu/blob/3feb3f2b51ca6682fe1badc871db412d631c83d2/README.md